### PR TITLE
update ip address on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     volumes:
       - db-data:/var/lib/mysql
     healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost", "-uroot", "-ppassword" ]
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "127.0.0.1", "-uroot", "-ppassword" ]
       interval: 5s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
Closes #34
Pathway changed from "localhost" to "127.0.0.1" in docker-compose.yml (healthcheck).
This will help to avoid connection to temporary initialization server and  ensures that the health check only connects to the actual server which is ready to accept connections.

